### PR TITLE
added more whitespace to host entry message

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -94,9 +94,13 @@ Vagrant.configure(2) do |config|
 
   # Show IP address and hostname
   config.vm.provision "shell", inline: "
+  echo \" \"
   echo \"--- PUT THIS LINE IN YOUR HOST FILE ---\"
+  echo \" \"
   echo `/sbin/ifconfig eth1 | grep 'inet addr:' | cut -d: -f2 | awk '{ print $1}'` `hostname -f`
-  echo \"----------------------------------\"
+  echo \" \"
+  echo \"---------------------------------------\"
+  echo \" \"
   ", run: "always"
 
   # Introduction message


### PR DESCRIPTION
added more whitespace to host entry message and a few dashes to match the length of the first line

![message](https://cloud.githubusercontent.com/assets/1577992/10118964/2245854e-6488-11e5-85f9-efd09d27625a.PNG)
